### PR TITLE
fix: addition check for string `code` for monospaced fonts

### DIFF
--- a/ts/content.ts
+++ b/ts/content.ts
@@ -58,7 +58,7 @@ const changeFontFamily = (
     const fontFamily = getComputedStyle(element).fontFamily.toLowerCase();
 
     if (fontFamily) {
-        if (fontFamily.includes("mono") || fontFamily.includes("code")) {
+        if (fontFamily.includes("mono") || fontFamily.includes(" code")) {
             customizeFont(element, monospace);
         } else if (fontFamily.includes("sans")) {
             customizeFont(element, sansSerif);

--- a/ts/content.ts
+++ b/ts/content.ts
@@ -58,7 +58,7 @@ const changeFontFamily = (
     const fontFamily = getComputedStyle(element).fontFamily.toLowerCase();
 
     if (fontFamily) {
-        if (fontFamily.includes("mono")) {
+        if (fontFamily.includes("mono") || fontFamily.includes("code")) {
             customizeFont(element, monospace);
         } else if (fontFamily.includes("sans")) {
             customizeFont(element, sansSerif);


### PR DESCRIPTION
This fix shortcircuits the logic to allow using `Google Sans Code`